### PR TITLE
Add jwt authenticatioin middleware

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -13,5 +13,8 @@
       "level": "trace",
       "stream": "ringBuffer"
     }]
+  },
+  "auth": {
+    "secret": "secret"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "fh-cluster": "0.3.0",
     "fh-config": "1.1.0",
     "fh-logger": "0.5.1",
+    "jsonwebtoken": "^7.2.1",
+    "lodash": "^4.17.2",
     "mongoose": "4.5.1",
     "optimist": "0.6.1"
   },

--- a/src/app.js
+++ b/src/app.js
@@ -15,6 +15,7 @@ import buildEndpoints from './endpoints/http';
 import errorHandler from './endpoints/http/error.js';
 import {setLogger} from './logger';
 import validation from '../config/validation';
+import jwtAuthenticate from './middleware/jwt-authenticate';
 
 var TITLE = "fh-dataman";
 process.env.component = TITLE;
@@ -103,11 +104,15 @@ function startWorker(logger, fhconfig) {
 function startApp(logger, fhconfig) {
   const app = express();
   app.use(logger.requestIdMiddleware);
-     // Enable CORS for all requests
+
+  // Enable CORS for all requests
   app.use(cors());
 
   // Request logging
   app.use(bunyanLogger({ logger: logger, parseUA: false, genReqId: req => req.header(logger.requestIdHeader) }));
+
+  // Authenticate requests
+  app.use(jwtAuthenticate({ secret: fhconfig.value('auth.secret') }));
 
   // Parse JSON payloads
   app.use(bodyParser.json({limit: fhconfig.value('fhmbaas.maxpayloadsize') || "20mb"}));

--- a/src/middleware/jwt-authenticate/UnauthorizedError.js
+++ b/src/middleware/jwt-authenticate/UnauthorizedError.js
@@ -1,0 +1,11 @@
+function UnauthorizedError(message) {
+  this.name = 'UnauthorizedError';
+  this.message = message || 'Unauthorized Error';
+  this.code = 401;
+  this.stack = (new Error()).stack;
+}
+
+UnauthorizedError.prototype = Object.create(Error.prototype);
+UnauthorizedError.prototype.constructor = UnauthorizedError;
+
+export default UnauthorizedError;

--- a/src/middleware/jwt-authenticate/index.js
+++ b/src/middleware/jwt-authenticate/index.js
@@ -1,0 +1,41 @@
+import _ from 'lodash';
+import jwt from 'jsonwebtoken';
+import UnauthorizedError from './UnauthorizedError';
+
+/**
+ * Middleware for authenticating requests based on JSON Web Tokens.
+ *
+ * @param {object} options - Options for the middleware.
+ * @param {string} options.secret - Secret key to use for verifying JSON web token.
+ * @param {string} [options.payloadPath=user] - Decoded JSON web token payload will be attached to request[payloadPath].
+ *                                              Uses 'lodash.set' syntax. Defaults to 'user'.
+ */
+export default (options={}) => {
+
+  if (!options.secret) {
+    throw new Error('Authentication module options.secret parameter is required');
+  }
+
+  function middleware(req, res, next) {
+    if (!req.headers || !req.headers.authorization) {
+      return next(new UnauthorizedError('Authorisation header has not been set'));
+    }
+
+    const [schema='', token=''] = req.headers.authorization.split(' ');
+    if (schema !== 'Bearer' || !token) {
+      return next(new UnauthorizedError('Authorisation header should use "Bearer <token>" schema'));
+    }
+
+    jwt.verify(token, options.secret, (err, payload) => {
+      if (err) {
+        return next(new UnauthorizedError(err.message));
+      }
+
+      _.set(req, options.payloadPath || 'user', payload);
+
+      next(null);
+    });
+  }
+
+  return middleware;
+};

--- a/src/middleware/jwt-authenticate/test/jwtauth_test.js
+++ b/src/middleware/jwt-authenticate/test/jwtauth_test.js
@@ -1,0 +1,91 @@
+import supertest from 'supertest';
+import assert from 'assert';
+import express from 'express';
+import jwtAuthenticate from '../';
+import jwt from 'jsonwebtoken';
+
+const app = express();
+const testEndPoint = '/test/endpoint';
+const secret = 'test-secret';
+const payloadPath = 'authenticateData';
+const payload = {
+  email: 'test@email.com',
+  username: 'user101'
+};
+
+
+app.use(jwtAuthenticate({ secret: secret, payloadPath: payloadPath }));
+app.use((err, req, res, next) => {
+  if (err) {
+    return res.status(err.code).send({ message: err.message });
+  }
+
+  return res.status(200).end();
+});
+app.get(testEndPoint, (req, res) => {
+  res.status(200).send(req[payloadPath]);
+});
+
+export function secretRequired(done) {
+  assert.throws(jwtAuthenticate, Error, 'options.secret parameter is required');
+  done();
+}
+
+export function authenticationHeaderMustBeSet(done) {
+  supertest(app)
+    .get(testEndPoint)
+    .expect(401)
+    .expect(res => {
+      assert.equal(res.body.message, 'Authorisation header has not been set');
+    })
+    .end(done);
+}
+
+export function authenticationHeaderMustUseCorrectSchema(done) {
+  supertest(app)
+    .get(testEndPoint)
+    .set('Authorization', 'Not-Bearer token')
+    .expect(401)
+    .expect(res => {
+      assert.equal(res.body.message, 'Authorisation header should use "Bearer <token>" schema');
+    })
+    .end(done);
+}
+
+export function authenticationHeaderMustHaveToken(done) {
+  supertest(app)
+    .get(testEndPoint)
+    .set('Authorization', 'Bearer')
+    .expect(401)
+    .expect(res => {
+      assert.equal(res.body.message, 'Authorisation header should use "Bearer <token>" schema');
+    })
+    .end(done);
+}
+
+export function mustBeAValidToken(done) {
+  supertest(app)
+    .get(testEndPoint)
+    .set('Authorization', 'Bearer not-a-valid-token')
+    .expect(401)
+    .expect(res => {
+      assert.equal(res.body.message, 'jwt malformed');
+    })
+    .end(done);
+}
+
+export function dataShouldBeAddedToSuccesfulRequestAtPayloadPath(done) {
+  const token = jwt.sign(payload, secret);
+  supertest(app)
+    .get(testEndPoint)
+    .set('Authorization', `Bearer ${token}`)
+    .expect(200)
+    .end((err, response) => {
+
+      assert.ok(response.body);
+      assert.equal(response.body.email, 'test@email.com');
+      assert.equal(response.body.username, 'user101');
+
+      done();
+    });
+}


### PR DESCRIPTION
# Motivation
Ticket:  https://issues.jboss.org/browse/RHMAP-11580
We need to make sure the user has permission to use the service.

# Solution 
In conjunction with https://github.com/fheng/fh-supercore/pull/897 which is generating JSON web tokens and payload this new middleware will check all requests to see if a valid JSON web token is present and blocking access if not.