### PR TITLE
make app.sh executable after build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,6 +36,15 @@ module.exports = function(grunt) {
           ext: '.js'
         }]
       }
+    },
+
+    chmod: {
+      options: {
+        mode: '755'
+      },
+      binaries: {
+        src: ['lib/app.js']
+      }
     }
   });
 
@@ -44,7 +53,7 @@ module.exports = function(grunt) {
   grunt.registerTask('unit', ['eslint', 'fh:unit']);
   grunt.registerTask('integration', ['eslint', 'babel', 'fh:accept']);
 
-  grunt.registerTask('default', ['eslint', 'babel', 'fh:default']);
+  grunt.registerTask('default', ['eslint', 'babel', 'chmod', 'fh:default']);
 
   grunt.registerTask('coverage', ['clean:fh-cov', 'shell:fh-run-array:unit_cover']);
 };

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "cross-env": "^3.1.3",
     "grunt": "^1.0.1",
     "grunt-babel": "^6.0.0",
+    "grunt-chmod": "^1.1.1",
     "grunt-fh-build": "^1.0.2",
     "load-grunt-tasks": "^3.5.2",
     "mocha": "^2.3.3",


### PR DESCRIPTION
The `app.sh` file needs the executable flag. But because this file is created by babel, we need that as part of the build pipeline.