### PR TITLE
Remove default export sizeLimit of 1GB

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -26,7 +26,7 @@
     "cluster/reseller/customer/domain/project/cloud-apps/data-browser"
   ],
   "port": 8822,
-  "sizeLimit": 524288000,
+  "sizeLimit": 1000000000,
   "rootUrl": "/",
   "mbaas": {
     "url": "https://api.feedhenry.me",

--- a/src/endpoints/http/collections/export/test/index_test.js
+++ b/src/endpoints/http/collections/export/test/index_test.js
@@ -48,7 +48,7 @@ export function testExportReqCollections(done) {
   archive.default = () => fs.createReadStream(`${__dirname}/export.json`);
 
   fhconfig.init('config/dev.json', () => {
-    exportCollections(mockDb, reqCollections, supportedFormat, new MockWriteStream).then(() => {
+    exportCollections(mockDb, reqCollections, supportedFormat, new MockWriteStream()).then(() => {
       parsers.default.json = originalParser;
       done();
     });
@@ -66,7 +66,7 @@ export function testExportAllCollections(done) {
   archive.default = () => fs.createReadStream(`${__dirname}/export.json`);
 
   fhconfig.init('config/dev.json', () => {
-    exportCollections(mockDb, allCollections, supportedFormat, new MockWriteStream).then(() => {
+    exportCollections(mockDb, allCollections, supportedFormat, new MockWriteStream()).then(() => {
       parsers.default.json = originalParser;
       done();
     });
@@ -83,7 +83,7 @@ export function testExportZipFail(done) {
   parsers.default.json = sinon.stub().returns({ "_id": 1, "item": "bottle", "qty": 30 });
   archive.default = () => fs.createReadStream(`${__dirname}/error-data.json`);
 
-  exportCollections(mockDb, allCollections, supportedFormat, new MockWriteStream).catch(() =>{
+  exportCollections(mockDb, allCollections, supportedFormat, new MockWriteStream()).catch(() =>{
     parsers.default.json = originalParser;
     done();
   });
@@ -105,7 +105,7 @@ export function testCollectionSizeTooBig(done) {
   collectionStub.returns({ stats: statsStub });
   fhconfig.init('config/dev.json', () => {
     exportCollections(mockDb, allCollections, supportedFormat).catch(err => {
-      assert.equal(err.message, 'Cannot export collections larger than a gigabyte');
+      assert.equal(err.message, 'Cannot export collections larger than 1 GB');
       done();
     });
   });


### PR DESCRIPTION
I am removing the size limit as part of this feature will be to export larger collections.
The limit is still configurable if needed but a falsey value will set no limit