### PR TITLE
Improve import export

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -4,6 +4,7 @@
   "https": {
     "enabled": false
   },
+  "memoryLimit": 30,
   "logger": {
     "name": "dataman",
     "streams": [{

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3135,6 +3135,55 @@
         }
       }
     },
+    "stream-meter": {
+      "version": "1.0.4",
+      "from": "stream-meter@latest",
+      "resolved": "https://registry.npmjs.org/stream-meter/-/stream-meter-1.0.4.tgz",
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.3",
+          "from": "readable-stream@>=2.1.4 <3.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "dependencies": {
+            "core-util-is": {
+              "version": "1.0.2",
+              "from": "core-util-is@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "from": "inherits@>=2.0.3 <2.1.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "from": "isarray@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+            },
+            "process-nextick-args": {
+              "version": "1.0.7",
+              "from": "process-nextick-args@>=1.0.6 <1.1.0",
+              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+            },
+            "safe-buffer": {
+              "version": "5.1.1",
+              "from": "safe-buffer@>=5.1.1 <5.2.0",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+            },
+            "string_decoder": {
+              "version": "1.0.3",
+              "from": "string_decoder@>=1.0.3 <1.1.0",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "from": "util-deprecate@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+            }
+          }
+        }
+      }
+    },
     "yauzl": {
       "version": "2.8.0",
       "from": "yauzl@>=2.7.0 <3.0.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "mongoose": "4.5.1",
     "optimist": "0.6.1",
     "request": "2.79.0",
+    "stream-meter": "~1.0.4",
     "yauzl": "^2.7.0",
     "yazl": "^2.4.2"
   },

--- a/src/Errors/RequestEntityTooLargeError.js
+++ b/src/Errors/RequestEntityTooLargeError.js
@@ -1,0 +1,9 @@
+class RequestEntityTooLargeError extends Error {
+  constructor(message, fileName, lineNumber) {
+    super(message || 'Request Entity Too Large', fileName, lineNumber);
+    this.code = 413;
+    this.name = 'RequestEntityTooLargeError';
+  }
+}
+
+export default RequestEntityTooLargeError;

--- a/src/endpoints/http/collections/export/lib/parser.js
+++ b/src/endpoints/http/collections/export/lib/parser.js
@@ -7,7 +7,7 @@ class json extends stream.Transform {
   }
 
   _transform(data, encoding, cb) {
-    data = JSON.stringify(data);
+    data = `${JSON.stringify(data)}\r\n`;
     this.push(data);
     cb();
   }

--- a/src/endpoints/http/collections/import/index.js
+++ b/src/endpoints/http/collections/import/index.js
@@ -72,6 +72,7 @@ export function insertCollection(file, name, db) {
 /**
  * Insert all the files contents into the database as getCollectionName.
  * file contents are expected to be compatible with mongodb insert interface.
+ * Executes sequentially.
  *
  * @param {Filestream[]} files - Array of ReadStreams to read the file data from.
  * @param {object} db - The mongodb connection.
@@ -79,5 +80,10 @@ export function insertCollection(file, name, db) {
  * @returns {Promise}
  */
 export function insertCollections(files, db) {
-  return Promise.all(files.map(file => insertCollection(file, getCollectionName(file.meta.fileName), db)));
+  return files.reduce((chain, file) => {
+    const collectionName = getCollectionName(file.meta.fileName);
+    return chain
+      .then(result => insertCollection(file, collectionName, db)
+      .then(name => result.concat([name])));
+  }, Promise.resolve([]));
 }

--- a/src/endpoints/http/collections/import/mongoStream/lib/BufferError.js
+++ b/src/endpoints/http/collections/import/mongoStream/lib/BufferError.js
@@ -1,0 +1,9 @@
+class BufferError extends Error {
+  constructor(message, fileName, lineNumber) {
+    super(message || 'Received Buffer error', fileName, lineNumber);
+    this.code = 22000;
+    this.name = 'BufferError';
+  }
+}
+
+export default BufferError;

--- a/src/endpoints/http/collections/import/mongoStream/lib/InsertMixin.js
+++ b/src/endpoints/http/collections/import/mongoStream/lib/InsertMixin.js
@@ -1,4 +1,4 @@
-import InsertReceivedBufferError from './InsertReceivedBufferError';
+import BufferError from './BufferError';
 
 /**
  * Utility to insert data into the mongodb collection
@@ -10,7 +10,7 @@ import InsertReceivedBufferError from './InsertReceivedBufferError';
  */
 function insert(data, fn, cb) {
   if (data instanceof Buffer) {
-    return this.emit('error', new InsertReceivedBufferError());
+    return this.emit('error', new BufferError());
   }
 
   if (this.collection) {

--- a/src/endpoints/http/collections/import/mongoStream/lib/InsertReceivedBufferError.js
+++ b/src/endpoints/http/collections/import/mongoStream/lib/InsertReceivedBufferError.js
@@ -1,9 +1,0 @@
-class InsertReceivedBufferError extends Error {
-  constructor(message, fileName, lineNumber) {
-    super(message || 'InsertStream Received Buffer error', fileName, lineNumber);
-    this.code = 22000;
-    this.name = 'InsertReceivedBufferError';
-  }
-}
-
-export default InsertReceivedBufferError;

--- a/src/endpoints/http/index.js
+++ b/src/endpoints/http/index.js
@@ -15,7 +15,7 @@ function attachMiddlewares(router) {
 
   // Route level middleware
   var importEndpoint = router.route('/collections/import');
-  importEndpoint.post(parseFile());
+  importEndpoint.post(parseFile({memoryLimit: fhconfig.value('memoryLimit')}));
 }
 
 export default function buildAPI(server) {

--- a/src/middleware/parse-file/index.js
+++ b/src/middleware/parse-file/index.js
@@ -1,10 +1,17 @@
 import BusboyZip from './lib/BusboyZip';
 import parsers from './lib/parsers';
+import BatchStream from './lib/BatchStream';
 import UnsupportedMediaError from '../../Errors/UnsupportedMediaError';
+import RequestEntityTooLargeError from '../../Errors/RequestEntityTooLargeError';
 import customMimeTypes from './lib/customMimeTypes';
 import mime from 'mime';
+import os from 'os';
 
 mime.define(customMimeTypes);
+
+const defaultOptions = {
+  memoryLimit: 30
+};
 
 /**
  * Set stream parser chain on the uploaded file stream.
@@ -26,17 +33,53 @@ function setParsers(file, mimetype) {
 }
 
 /**
+ * Control the buffer size on the file.
+ * This adds a stream to the chain that controls the amount of memory used by the stream.
+ * The stream will write in batches, only when the buffer is full (or the underlying ReadStream ends) will all data be flushed.
+ * The buffer is fully flushed before allowing more writes to the stream.
+ *
+ * @param {object} file - FileReadStream.
+ * @param {Number} memoryLimit -  The percentage of free RAM to be used when reading files.
+ *
+ * @returns {object} - A stream that writes in batches instead of flowing.
+ */
+function setBufferLimit(file, memoryLimit) {
+  return file.pipe(new BatchStream({
+    highWaterMark: getFreeKilobytes(memoryLimit)
+  }));
+}
+
+/**
+ * Get the number of free memory in kilobytes to be allocated to stream buffer size.
+ * Calculated from percentage of memory indicated by memoryLimit.
+ *
+ * @param {Number} memoryLimit -  The percentage of free memory to be used.
+ *
+ * @returns {Number} - Number of free kilobytes of memory.
+ */
+function getFreeKilobytes(memoryLimit) {
+  return  Math.floor(os.freemem() * (memoryLimit / 100));
+}
+
+/**
  * Middleware to parse incoming form file data.
  * parse-file will attach a stream parser chain to the file to present the data in the required format.
  * Parsers will be retrieved from parsers.js and will be mapped based on the mime type of the incoming file.
+ *
+ * @param {object} options
+ * @param {object} [options.memoryLimit=30] - The percentage of free RAM to be used as a memory limit when reading files.
  */
-export default function() {
+export default function(options={}) {
+
+  options = Object.assign(defaultOptions, options);
 
   return (req, res, next) => {
     let busboyZip;
     try {
-      // BusboyZip will throw 'Unsupported content type' and 'Missing Content-Type' errors.
-      busboyZip = new BusboyZip({ headers: req.headers });
+      busboyZip = new BusboyZip({
+        headers: req.headers,
+        zipMemoryLimit: getFreeKilobytes(options.memoryLimit)
+      });
     } catch (err) {
       return next(new UnsupportedMediaError());
     }
@@ -50,6 +93,7 @@ export default function() {
       }
 
       const mimetype = mime.lookup(fileName);
+      file = setBufferLimit(file, options.memoryLimit);
       file = setParsers(file, mimetype) || file;
       file.meta = {fileName, encoding, mimetype};
       req.files.push(file);
@@ -57,6 +101,10 @@ export default function() {
 
     busboyZip.on('end', next);
     busboyZip.on('error', next);
+    busboyZip.on('memorylimit', () => {
+      req.files.forEach(file => file.resume());
+      next(new RequestEntityTooLargeError());
+    });
 
     req.pipe(busboyZip);
   };

--- a/src/middleware/parse-file/lib/BatchStream.js
+++ b/src/middleware/parse-file/lib/BatchStream.js
@@ -1,0 +1,33 @@
+import { Transform } from 'stream';
+
+/**
+ * This class adds the capability to control the flow of data passed through a stream chain.
+ * Batchstream will uncork when the buffer is full and cork again when the buffer is drained.
+ * Batch size is controlled by the highWatermark option.
+ */
+class BatchStream extends Transform {
+  constructor(options={}) {
+    super(options);
+
+    this.cork();
+
+    this.on('drain', this.cork.bind(this));
+  }
+
+  write(chunk, encoding, callback) {
+    const hasBufferSpace = super.write(chunk, encoding, callback);
+    if (!hasBufferSpace) {
+      process.nextTick(this.uncork.bind(this));
+    }
+
+    return hasBufferSpace;
+  }
+
+  _transform(data, encoding, callback) {
+    this.push(data);
+    callback();
+  }
+
+}
+
+export default BatchStream;

--- a/src/middleware/parse-file/lib/BusboyZip.js
+++ b/src/middleware/parse-file/lib/BusboyZip.js
@@ -51,7 +51,9 @@ export default class extends EventEmitter {
         return file.resume();
       }
 
-      self.filesFromZips.push(new Zip(file).getEntries());
+      const zip = new Zip(file, options.zipMemoryLimit);
+      zip.on('memorylimit', self.emit.bind(self, 'memorylimit'));
+      self.filesFromZips.push(zip.getEntries());
     });
   }
 

--- a/test/integration/test_conf.json
+++ b/test/integration/test_conf.json
@@ -4,6 +4,7 @@
   "https": {
     "enabled": false
   },
+  "memoryLimit": 30,
   "logger": {
     "name": "dataman",
     "streams": [


### PR DESCRIPTION
Improvements to import/export

- exported JSON needs to be on a new line to be read by mongoimport locally
- Setting import memory limits. Configurable amount defaulting to 30%