### PR TITLE
Add filtering export

### DIFF
--- a/api-docs/swagger.yaml
+++ b/api-docs/swagger.yaml
@@ -154,7 +154,12 @@ paths:
           type: string
           name: format
           description: The format the collections are to be exported in
-          required: true 
+          required: true
+        - in: query
+          type: string
+          name: filter
+          description: A filter to apply to the collection before exporting.
+          required: false
       tags:
         - Collections
       responses:

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -124,7 +124,7 @@
             },
             "mime-types": {
               "version": "2.1.16",
-              "from": "mime-types@>=2.1.11 <2.2.0",
+              "from": "mime-types@>=2.1.15 <2.2.0",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
               "dependencies": {
                 "mime-db": {
@@ -200,13 +200,13 @@
       "resolved": "https://registry.npmjs.org/compression/-/compression-1.6.2.tgz",
       "dependencies": {
         "accepts": {
-          "version": "1.3.3",
+          "version": "1.3.4",
           "from": "accepts@>=1.3.3 <1.4.0",
-          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
           "dependencies": {
             "mime-types": {
               "version": "2.1.16",
-              "from": "mime-types@>=2.1.11 <2.2.0",
+              "from": "mime-types@>=2.1.16 <2.2.0",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
               "dependencies": {
                 "mime-db": {
@@ -234,9 +234,9 @@
           "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.11.tgz",
           "dependencies": {
             "mime-db": {
-              "version": "1.29.0",
+              "version": "1.30.0",
               "from": "mime-db@>=1.29.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz"
             }
           }
         },
@@ -433,7 +433,7 @@
                     },
                     "string_decoder": {
                       "version": "1.0.3",
-                      "from": "string_decoder@>=1.0.0 <1.1.0",
+                      "from": "string_decoder@>=1.0.3 <1.1.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
                     },
                     "util-deprecate": {
@@ -489,13 +489,13 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.15.2.tgz",
       "dependencies": {
         "accepts": {
-          "version": "1.3.3",
+          "version": "1.3.4",
           "from": "accepts@>=1.3.3 <1.4.0",
-          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
           "dependencies": {
             "mime-types": {
               "version": "2.1.16",
-              "from": "mime-types@>=2.1.11 <2.2.0",
+              "from": "mime-types@>=2.1.15 <2.2.0",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
               "dependencies": {
                 "mime-db": {
@@ -718,7 +718,7 @@
             },
             "mime-types": {
               "version": "2.1.16",
-              "from": "mime-types@>=2.1.11 <2.2.0",
+              "from": "mime-types@>=2.1.15 <2.2.0",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
               "dependencies": {
                 "mime-db": {
@@ -758,9 +758,9 @@
               "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.5.tgz",
               "dependencies": {
                 "nan": {
-                  "version": "2.6.2",
+                  "version": "2.7.0",
                   "from": "nan@>=2.3.3 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz"
+                  "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz"
                 }
               }
             },
@@ -1930,7 +1930,7 @@
     },
     "fh-mbaas-client": {
       "version": "1.1.0",
-      "from": "fh-mbaas-client@1.1.0",
+      "from": "fh-mbaas-client@>=1.1.0 <1.2.0",
       "resolved": "https://registry.npmjs.org/fh-mbaas-client/-/fh-mbaas-client-1.1.0.tgz",
       "dependencies": {
         "fh-logger": {
@@ -2470,7 +2470,7 @@
         },
         "xtend": {
           "version": "4.0.1",
-          "from": "xtend@>=4.0.1 <5.0.0",
+          "from": "xtend@>=4.0.1 <4.1.0",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
         }
       }
@@ -2481,9 +2481,99 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
     },
     "mime": {
-      "version": "1.3.6",
+      "version": "1.4.0",
       "from": "mime@>=1.3.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz"
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.0.tgz"
+    },
+    "mongodb": {
+      "version": "2.2.31",
+      "from": "mongodb@>=2.2.19 <3.0.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.31.tgz",
+      "dependencies": {
+        "es6-promise": {
+          "version": "3.2.1",
+          "from": "es6-promise@3.2.1",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz"
+        },
+        "mongodb-core": {
+          "version": "2.1.15",
+          "from": "mongodb-core@2.1.15",
+          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.15.tgz",
+          "dependencies": {
+            "bson": {
+              "version": "1.0.4",
+              "from": "bson@>=1.0.4 <1.1.0",
+              "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.4.tgz"
+            },
+            "require_optional": {
+              "version": "1.0.1",
+              "from": "require_optional@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+              "dependencies": {
+                "semver": {
+                  "version": "5.4.1",
+                  "from": "semver@>=5.1.0 <6.0.0",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz"
+                },
+                "resolve-from": {
+                  "version": "2.0.0",
+                  "from": "resolve-from@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.7",
+          "from": "readable-stream@2.2.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
+          "dependencies": {
+            "buffer-shims": {
+              "version": "1.0.0",
+              "from": "buffer-shims@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "from": "core-util-is@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "from": "isarray@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "from": "inherits@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+            },
+            "process-nextick-args": {
+              "version": "1.0.7",
+              "from": "process-nextick-args@>=1.0.6 <1.1.0",
+              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+            },
+            "string_decoder": {
+              "version": "1.0.3",
+              "from": "string_decoder@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+              "dependencies": {
+                "safe-buffer": {
+                  "version": "5.1.1",
+                  "from": "safe-buffer@>=5.1.0 <5.2.0",
+                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+                }
+              }
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "from": "util-deprecate@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+            }
+          }
+        }
+      }
     },
     "mongodb-extended-json": {
       "version": "1.7.0",
@@ -2902,9 +2992,9 @@
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
             },
             "is-my-json-valid": {
-              "version": "2.16.0",
+              "version": "2.16.1",
               "from": "is-my-json-valid@>=2.12.4 <3.0.0",
-              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
               "dependencies": {
                 "generate-function": {
                   "version": "2.0.0",
@@ -3081,12 +3171,12 @@
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "from": "json-stringify-safe@>=5.0.1 <6.0.0",
+          "from": "json-stringify-safe@>=5.0.1 <5.1.0",
           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
         },
         "mime-types": {
           "version": "2.1.16",
-          "from": "mime-types@>=2.1.11 <2.2.0",
+          "from": "mime-types@>=2.1.7 <2.2.0",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
           "dependencies": {
             "mime-db": {
@@ -3137,7 +3227,7 @@
     },
     "stream-meter": {
       "version": "1.0.4",
-      "from": "stream-meter@latest",
+      "from": "stream-meter@>=1.0.4 <1.1.0",
       "resolved": "https://registry.npmjs.org/stream-meter/-/stream-meter-1.0.4.tgz",
       "dependencies": {
         "readable-stream": {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "proxyquire": "^1.7.10",
     "sinon": "^1.17.6",
     "sinon-stub-promise": "^4.0.0",
-    "supertest": "^2.0.1"
+    "supertest": "^2.0.1",
+    "unzip-stream": "~0.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "request": "2.79.0",
     "stream-meter": "~1.0.4",
     "yauzl": "^2.7.0",
-    "yazl": "^2.4.2"
+    "yazl": "^2.4.2",
+    "mongodb": "^2.2.19"
   },
   "devDependencies": {
     "babel-core": "^6.18.2",
@@ -77,7 +78,6 @@
     "grunt-fh-build": "^1.0.2",
     "load-grunt-tasks": "^3.5.2",
     "mocha": "^2.3.3",
-    "mongodb": "^2.2.19",
     "nyc": "^10.0.0",
     "proxyquire": "^1.7.10",
     "sinon": "^1.17.6",

--- a/src/Errors/BadRequestError.js
+++ b/src/Errors/BadRequestError.js
@@ -1,0 +1,9 @@
+class BadRequestError extends Error {
+  constructor(message, fileName, lineNumber) {
+    super(message || 'The request could not be understood by the server due to malformed syntax.', fileName, lineNumber);
+    this.code = 400;
+    this.name = 'BadRequestError';
+  }
+}
+
+export default BadRequestError;

--- a/src/endpoints/http/collections/export/test/index_test.js
+++ b/src/endpoints/http/collections/export/test/index_test.js
@@ -34,7 +34,11 @@ const mockDb = {
 };
 
 const exportCollections = index.default;
-const supportedFormat = 'json';
+const options = {
+  format: 'json',
+  mongoQuery: {}
+};
+
 const allCollections = [];
 const reqCollections = ['collection1'];
 
@@ -48,7 +52,7 @@ export function testExportReqCollections(done) {
   archive.default = () => fs.createReadStream(`${__dirname}/export.json`);
 
   fhconfig.init('config/dev.json', () => {
-    exportCollections(mockDb, reqCollections, supportedFormat, new MockWriteStream()).then(() => {
+    exportCollections(mockDb, reqCollections, options, new MockWriteStream()).then(() => {
       parsers.default.json = originalParser;
       done();
     });
@@ -66,7 +70,7 @@ export function testExportAllCollections(done) {
   archive.default = () => fs.createReadStream(`${__dirname}/export.json`);
 
   fhconfig.init('config/dev.json', () => {
-    exportCollections(mockDb, allCollections, supportedFormat, new MockWriteStream()).then(() => {
+    exportCollections(mockDb, allCollections, options, new MockWriteStream()).then(() => {
       parsers.default.json = originalParser;
       done();
     });
@@ -83,7 +87,7 @@ export function testExportZipFail(done) {
   parsers.default.json = sinon.stub().returns({ "_id": 1, "item": "bottle", "qty": 30 });
   archive.default = () => fs.createReadStream(`${__dirname}/error-data.json`);
 
-  exportCollections(mockDb, allCollections, supportedFormat, new MockWriteStream()).catch(() =>{
+  exportCollections(mockDb, allCollections, options, new MockWriteStream()).catch(() =>{
     parsers.default.json = originalParser;
     done();
   });
@@ -93,7 +97,7 @@ export function testCollectionDoesNotExist(done) {
   listStub.resolves([{name: 'indexes'}, {name: 'users'}, {name: 'collection1'}, {name: 'collection2'}]);
   statsStub.yields({ message: 'ns not found'});
   collectionStub.returns({ stats: statsStub });
-  exportCollections(mockDb, allCollections, supportedFormat).catch(err => {
+  exportCollections(mockDb, allCollections, options).catch(err => {
     assert.equal(err.message, 'collection1 collection does not exist');
     done();
   });
@@ -104,7 +108,7 @@ export function testCollectionSizeTooBig(done) {
   statsStub.yields(null, { size: fhconfig.value('sizeLimit') });
   collectionStub.returns({ stats: statsStub });
   fhconfig.init('config/dev.json', () => {
-    exportCollections(mockDb, allCollections, supportedFormat).catch(err => {
+    exportCollections(mockDb, allCollections, options).catch(err => {
       assert.equal(err.message, 'Cannot export collections larger than 1 GB');
       done();
     });

--- a/src/endpoints/http/collections/index.js
+++ b/src/endpoints/http/collections/index.js
@@ -89,19 +89,19 @@ export function collectionsHandler(router) {
   });
 
   router.get('/collections/export', (req, res, next) => {
-    const supportedFormats = ["csv", "json", "bson"];
+    const supportedFormats = ['csv', 'json', 'bson'];
     if (!req.query.format.length) {
       return next({ message: 'No format selected', code: statusCodes.BAD_REQUEST });
     } else if (supportedFormats.indexOf(req.query.format) < 0) {
       return next(new UnsupportedMediaError(`${req.query.format} is not supported`));
     }
+
     res.setHeader('Content-disposition', 'attachment; filename=collections.zip');
     res.setHeader('Content-type', 'application/zip');
-
     const collections = req.query.collections ? req.query.collections.split(',') : [];
     req.log.debug(collections.length ? collections : ['ALL COLLECTIONS'], 'collection(s) export started');
 
-    exportCollections(req.db, collections, req.query.format, res)
+    exportCollections(req.db, collections, req.query, res)
       .then(() => {
         req.log.trace(collections.length ? collections : ['ALL COLLECTIONS'], ' Collection(s) export complete');
         res.status(statusCodes.OK).end();

--- a/src/endpoints/http/index.js
+++ b/src/endpoints/http/index.js
@@ -4,6 +4,7 @@ import fhconfig from 'fh-config';
 import dbConnection from '../../middleware/dbConnection';
 import parseFile from '../../middleware/parse-file';
 import authorize from '../../middleware/route-authorize';
+import mongoQuery from '../../middleware/mongoQuery';
 
 const PATH_PREFIX = "/api/:domain/:envId/:appGuid/data";
 
@@ -16,6 +17,8 @@ function attachMiddlewares(router) {
   // Route level middleware
   var importEndpoint = router.route('/collections/import');
   importEndpoint.post(parseFile({memoryLimit: fhconfig.value('memoryLimit')}));
+  var exportEndpoint = router.route('/collections/export');
+  exportEndpoint.get(mongoQuery());
 }
 
 export default function buildAPI(server) {

--- a/src/middleware/mongoQuery/index.js
+++ b/src/middleware/mongoQuery/index.js
@@ -1,0 +1,138 @@
+import _ from 'lodash';
+import * as mongodb from 'mongodb';
+import BadRequestError from '../../Errors/BadRequestError';
+
+/**
+ * Ensure that passed values are of the type indicated.
+ */
+var casters = {
+  'String': function(val) {
+    return `${val}`;
+  },
+  'ObjectId': function(val) {
+    if (mongodb.ObjectId.isValid(val)) {
+      return new mongodb.ObjectId(val);
+    }
+
+    return undefined;
+  },
+  'Boolean': function(val) {
+    if (typeof val === 'boolean') {
+      return val;
+    }
+    if (`${val}`.toLowerCase() === 'true') {
+      return true;
+    } else if (`${val}`.toLowerCase() === 'false') {
+      return false;
+    }
+
+    return undefined;
+  },
+  'Date': function(val) {
+    return new Date(val);
+  },
+  'Null': function() {
+    return null;
+  },
+  'Number': function(val) {
+    var num = Number(val);
+    if (Number.isNaN(num)) {
+      return undefined;
+    }
+
+    return num;
+  }
+};
+
+/**
+ * Create an individual query
+ *
+ * @param {function} caster - function to cast the value.
+ * @param {string} operator - The operator, e.g. eq, ne, gt etc.
+ * @param {string} field - The document field name.
+ * @param {*} value - The value to be queried.
+ *
+ * @return {object} - Individual query on a field.
+ */
+function query(caster, operator, field, value) {
+  const query = {};
+  value = caster(value);
+  if (value !== undefined) {
+    operator = `$${operator}`;
+    if (operator === '$eq') {
+      query[field] = value;
+    } else {
+      const selector = {};
+      selector[operator] = value;
+      query[field] = selector;
+    }
+  }
+
+  return query;
+}
+
+/**
+ * Format the passed filter object into the corresponding mongo query object.
+ *
+ * @param {string} operator - The operator, e.g. eq, ne, gt etc.
+ * @param {string} field - The document field name.
+ * @param {Object} val - Object containg field info.
+ * @param {*} fieldInfo.val - The value to be queried.
+ * @param {Object} fieldInfo.type - The datatype.
+ *
+ * @return {object} - A mongo query from the passed filter.
+ */
+function formatFilter(operator, field, fieldInfo) {
+  const value = fieldInfo.value;
+  const type = fieldInfo.type;
+
+  if (type === 'Any') {
+    var allTypes = [];
+    _.each(casters, caster => {
+      const q = query(caster, operator, field, value);
+      if (Object.keys(q).length) {
+        allTypes.push(q);
+      }
+    });
+
+    return {$or: allTypes};
+  }
+
+  return query(casters[type], operator, field, value);
+}
+
+/**
+ * Middleware for parsing filter requests into mongo db queries.
+ *
+ */
+export default function() {
+
+  return (req, res, next) => {
+    if (!req.query.filter) {
+      req.query.mongoQuery = {};
+      return next();
+    }
+
+    let filter = req.query.filter;
+    try {
+      filter = filter && JSON.parse(filter);
+    } catch (err) {
+      return next(new BadRequestError('Malformed JSON in filter'));
+    }
+
+    const queries = [];
+    try {
+      _.each(filter, (selector, operator) => {
+        _.each(selector, (fieldInfo, field) => {
+          queries.push(formatFilter(operator, field, fieldInfo));
+        });
+      });
+    } catch (err) {
+      return next(new BadRequestError('Incorrectly formatted filter object'));
+    }
+
+    req.query.mongoQuery = {$and: queries};
+    next();
+  };
+
+}

--- a/src/middleware/mongoQuery/mongoQuery_test.js
+++ b/src/middleware/mongoQuery/mongoQuery_test.js
@@ -1,0 +1,46 @@
+import assert from 'assert';
+import mongoQuery from './';
+
+export function testEq(done) {
+  const mockReq = {query:{filter: JSON.stringify({"eq":{"fieldname":{"type":"String","value":"fieldvalue"}}})}};
+  const expectedMongoQuery = {
+    $and: [{fieldname: 'fieldvalue'}]
+  };
+
+  const middleware = mongoQuery();
+  middleware(mockReq, {}, err => {
+    assert.ok(!err);
+    assert.deepEqual(mockReq.query.mongoQuery, expectedMongoQuery);
+    done();
+  });
+}
+
+export function testNe(done) {
+  const mockReq = {query:{filter: JSON.stringify({"ne":{"fieldname":{"type":"String","value":"fieldvalue"}}})}};
+  const expectedMongoQuery = {
+    $and: [{fieldname: {$ne: 'fieldvalue'}}]
+  };
+
+  const middleware = mongoQuery();
+  middleware(mockReq, {}, err => {
+    assert.ok(!err);
+    assert.deepEqual(mockReq.query.mongoQuery, expectedMongoQuery);
+    done();
+  });
+}
+
+export function testAll(done) {
+  const mockReq = {query:{filter: JSON.stringify({"eq":{"fieldname": {"type": "Any", "value": "2.5"}}})}};
+
+  const middleware = mongoQuery();
+  middleware(mockReq, {}, err => {
+    assert.ok(!err);
+    const allQueries = mockReq.query.mongoQuery['$and'][0]['$or'];
+    assert.equal(allQueries.length, 4)  ;
+    assert.ok(allQueries.some(query => query.fieldname === '2.5'));
+    assert.ok(allQueries.some(query => query.fieldname === 2.5));
+    assert.ok(allQueries.some(query => query.fieldname === null));
+    assert.ok(allQueries.some(query => query.fieldname.toString() === new Date('2.5').toString()));
+    done();
+  });
+}


### PR DESCRIPTION
Adding filtering to the export feature.
Mimicking current functionality as they may be side by side if only import/export released first.

- Added a middleware to format current ngui filter object into a mongo query
- New tests
- Updated docs